### PR TITLE
Feature/15 create user management for admin page

### DIFF
--- a/src/main/java/com/swp391/OnlineEnglishLearningSystem/controller/AdminController.java
+++ b/src/main/java/com/swp391/OnlineEnglishLearningSystem/controller/AdminController.java
@@ -1,26 +1,46 @@
 package com.swp391.OnlineEnglishLearningSystem.controller;
 
 import com.swp391.OnlineEnglishLearningSystem.model.User;
+import com.swp391.OnlineEnglishLearningSystem.service.EmailService;
+import com.swp391.OnlineEnglishLearningSystem.service.RoleService;
+import com.swp391.OnlineEnglishLearningSystem.service.UploadService;
 import com.swp391.OnlineEnglishLearningSystem.service.UserService;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
 
 @Controller
 @RequestMapping("/admin")
 public class AdminController {
 
     private final UserService userService;
+    private final UploadService uploadService;
+    private final RoleService roleService;
+    private final PasswordEncoder passwordEncoder;
+    private final EmailService emailService;
 
-    public AdminController(UserService userService) {
+    public AdminController(UserService userService, UploadService uploadService, RoleService roleService, PasswordEncoder passwordEncoder, EmailService emailService) {
         this.userService = userService;
+        this.uploadService = uploadService;
+        this.roleService = roleService;
+        this.passwordEncoder = passwordEncoder;
+        this.emailService = emailService;
     }
 
+    //===================== DASHBOARD ========================
     @GetMapping("")
     public String admin(Model model) {
         List<User> users = userService.getAllUsers();
@@ -28,14 +48,159 @@ public class AdminController {
         return "admin/dashboard";
     }
 
-    @GetMapping("/user/detail/{id}")
-    public String getUserDetail(@PathVariable Long id, Model model) {
-        // Lấy user từ database theo ID
-        User user = userService.getUserById(id);
-        model.addAttribute("user", user);
+    @GetMapping("/users")
+    public String getUsers(Model model,
+                           @RequestParam(value = "role", required = false) String role,
+                           @RequestParam(value = "gender", required = false) String gender,
+                           @RequestParam(value = "enabled", required = false) Boolean enabled,
+                           @RequestParam(value = "search", required = false) String search,
+                           @RequestParam(value = "page", defaultValue = "0") int page,
+                           @RequestParam(value = "size", defaultValue = "10") int size,
+                           @RequestParam(value = "sort", defaultValue = "id") String sort,
+                           @RequestParam(value = "direction", defaultValue = "asc") String direction) {
 
-        // Trả về CHỈ fragment modal, không phải cả trang
-        return "admin/fragments :: userDetailModal";
+        // Tạo Sort object
+        Sort sortObj = createSort(sort, direction);
+        Pageable pageable = PageRequest.of(page, size, sortObj);
+
+        Page<User> userPage = this.userService.getUsersWithSpecs(pageable, gender, role, enabled, search);
+
+        model.addAttribute("userPage", userPage);
+        model.addAttribute("currentSort", sort);
+        model.addAttribute("currentDirection", direction);
+
+        int totalPages = userPage.getTotalPages();
+        if (totalPages > 0) {
+            List<Integer> pageNumbers = IntStream.rangeClosed(1, totalPages).boxed().toList();
+            model.addAttribute("pageNumbers", pageNumbers);
+        }
+
+        model.addAttribute("roles", roleService.findAll());
+        model.addAttribute("genders", User.Gender.values());
+        return "admin/userList";
     }
 
+    private Sort createSort(String sort, String direction) {
+        Sort.Direction sortDirection = direction.equalsIgnoreCase("desc") ?
+                Sort.Direction.DESC : Sort.Direction.ASC;
+
+        switch (sort) {
+            case "fullName":
+                return Sort.by(sortDirection, "fullName");
+            case "gender":
+                return Sort.by(sortDirection, "gender");
+            case "email":
+                return Sort.by(sortDirection, "email");
+            case "mobile":
+                return Sort.by(sortDirection, "mobile");
+            case "role":
+                return Sort.by(sortDirection, "role.name");
+            default: // id
+                return Sort.by(sortDirection, "id");
+        }
+    }
+
+    //===================== CREATE USER ========================
+    @GetMapping("/users/create")
+    public String createUserForm(Model model) {
+        model.addAttribute("user", new User());
+        model.addAttribute("genders", User.Gender.values());
+        model.addAttribute("roles", roleService.findAll());
+        return "admin/createUser";
+    }
+
+    @PostMapping("/users/create")
+    public String createUser(@Valid @ModelAttribute("user") User user,
+                             BindingResult bindingResult,
+                             @RequestParam("avatarFile") MultipartFile avatarFile,
+                             RedirectAttributes redirectAttributes,
+                             Model model) {
+
+        if (bindingResult.hasErrors()) {
+            model.addAttribute("genders", User.Gender.values());
+            model.addAttribute("roles", roleService.findAll());
+            return "admin/createUser";
+        }
+
+        try {
+            userService.ensureEmailNotExists(user.getEmail());
+
+            if (avatarFile != null && !avatarFile.isEmpty()) {
+                String avatarFileName = uploadService.uploadImage(avatarFile);
+                user.setAvatar(avatarFileName);
+            }
+
+            // Encode password and set default values
+            String encodedPassword = passwordEncoder.encode(user.getPassword());
+            user.setPassword(encodedPassword);
+            user.setEnabled(true);
+
+            // Save user
+            userService.save(user);
+
+            // Send email notification
+            emailService.sendEmail(user.getEmail(), "Tài khoản đã được tạo bởi Quản trị viên",
+                    emailService.buildEmailContent(user.getPassword()));
+
+            redirectAttributes.addFlashAttribute("successMessage", "Tạo người dùng thành công!");
+            return "redirect:/admin/users";
+
+        } catch (IllegalArgumentException e) {
+            bindingResult.rejectValue("email", "error.user", e.getMessage());
+            model.addAttribute("genders", User.Gender.values());
+            model.addAttribute("roles", roleService.findAll());
+            return "admin/createUser";
+        } catch (Exception e) {
+            bindingResult.rejectValue("email", "error.user", "Đã xảy ra lỗi khi tạo người dùng: " + e.getMessage());
+            model.addAttribute("genders", User.Gender.values());
+            model.addAttribute("roles", roleService.findAll());
+            return "admin/createUser";
+        }
+    }
+
+    //===================== UPDATE USER ========================
+    @GetMapping("/users/update/{id}")
+    public String getViewAndUpdateForm(@PathVariable("id") Long id, Model model){
+        try{
+            User user = this.userService.getUserById(id);
+            model.addAttribute("user", user);
+            model.addAttribute("roles", roleService.findAll());
+            return "admin/updateUser";
+        }catch(Exception e){
+            return "redirect:/admin/users";
+        }
+    }
+
+    @PostMapping("/users/update")
+    public String updateUser(@Valid @ModelAttribute("user") User user,
+                             BindingResult bindingResult,
+                             RedirectAttributes redirectAttributes){
+        if(bindingResult.hasErrors()){
+            return "admin/updateUser";
+        }
+        try{
+            User currentUser = this.userService.getUserById(user.getId());
+            currentUser.setRole(user.getRole());
+            currentUser.setEnabled(user.isEnabled());
+            this.userService.save(currentUser);
+
+            redirectAttributes.addFlashAttribute("successMessage", "Cập nhật người dùng thành công!");
+            return "redirect:/admin/users";
+        }catch(Exception e){
+            redirectAttributes.addFlashAttribute("errorMessage", "Lỗi khi cập nhật người dùng: " + e.getMessage());
+            return "redirect:/admin/users";
+        }
+    }
+
+    @GetMapping("/users/delete/{id}")
+    public String deleteUser(@PathVariable("id") Long id, RedirectAttributes redirectAttributes){
+        try{
+            this.userService.deleteById(id);
+            redirectAttributes.addFlashAttribute("successMessage", "Xóa người dùng thành công!");
+            return "redirect:/admin/users";
+        }catch(Exception e){
+            redirectAttributes.addFlashAttribute("errorMessage", "Lỗi khi xóa người dùng: " + e.getMessage());
+            return "redirect:/admin/users";
+        }
+    }
 }

--- a/src/main/java/com/swp391/OnlineEnglishLearningSystem/controller/AdminController.java
+++ b/src/main/java/com/swp391/OnlineEnglishLearningSystem/controller/AdminController.java
@@ -1,0 +1,41 @@
+package com.swp391.OnlineEnglishLearningSystem.controller;
+
+import com.swp391.OnlineEnglishLearningSystem.model.User;
+import com.swp391.OnlineEnglishLearningSystem.service.UserService;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+
+@Controller
+@RequestMapping("/admin")
+public class AdminController {
+
+    private final UserService userService;
+
+    public AdminController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping("")
+    public String admin(Model model) {
+        List<User> users = userService.getAllUsers();
+        model.addAttribute("users", users);
+        return "admin/dashboard";
+    }
+
+    @GetMapping("/user/detail/{id}")
+    public String getUserDetail(@PathVariable Long id, Model model) {
+        // Lấy user từ database theo ID
+        User user = userService.getUserById(id);
+        model.addAttribute("user", user);
+
+        // Trả về CHỈ fragment modal, không phải cả trang
+        return "admin/fragments :: userDetailModal";
+    }
+
+}

--- a/src/main/java/com/swp391/OnlineEnglishLearningSystem/model/User.java
+++ b/src/main/java/com/swp391/OnlineEnglishLearningSystem/model/User.java
@@ -57,7 +57,7 @@ public class User extends BaseEntity implements UserDetails {
 
     private boolean enabled;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "role_id")
     private UserRole role;
 

--- a/src/main/java/com/swp391/OnlineEnglishLearningSystem/repository/UserRepository.java
+++ b/src/main/java/com/swp391/OnlineEnglishLearningSystem/repository/UserRepository.java
@@ -1,6 +1,9 @@
 package com.swp391.OnlineEnglishLearningSystem.repository;
 
 import com.swp391.OnlineEnglishLearningSystem.model.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -8,4 +11,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     Optional<User> findByEmailAndEnabledTrue(String email);
+    Page<User> findAll(Specification<User> specs, Pageable pageale);
 }

--- a/src/main/java/com/swp391/OnlineEnglishLearningSystem/service/EmailService.java
+++ b/src/main/java/com/swp391/OnlineEnglishLearningSystem/service/EmailService.java
@@ -18,6 +18,7 @@ public class EmailService {
         this.mailSender = mailSender;
     }
 
+    @Async
     public void sendEmail(String to, String subject, String text) {
         SimpleMailMessage message = new SimpleMailMessage();
         message.setFrom(fromEmail);
@@ -35,6 +36,21 @@ public class EmailService {
         sendEmail(to, subject, text);
     }
 
+    public String buildEmailContent(String password) {
+        String url = "http://localhost:8080/login";
+        return String.format("""
+                Hello!
+
+                The admin has created a new account for you. Please login with the following password:
+                %s
+                Please log in via the link below:
+                %s
+
+                This link will expire in 24 hours.
+
+                If you did not request this, please ignore this email.
+                """, password, url);
+    }
     private String buildEmailContent(String token, EmailType type) {
         String url = switch (type) {
             case REGISTER -> "http://localhost:8080/confirmToken?token=" + token;

--- a/src/main/java/com/swp391/OnlineEnglishLearningSystem/service/RoleService.java
+++ b/src/main/java/com/swp391/OnlineEnglishLearningSystem/service/RoleService.java
@@ -1,4 +1,9 @@
 package com.swp391.OnlineEnglishLearningSystem.service;
 
+import com.swp391.OnlineEnglishLearningSystem.model.UserRole;
+
+import java.util.List;
+
 public interface RoleService {
+    List<UserRole> findAll();
 }

--- a/src/main/java/com/swp391/OnlineEnglishLearningSystem/service/RoleService.java
+++ b/src/main/java/com/swp391/OnlineEnglishLearningSystem/service/RoleService.java
@@ -1,0 +1,4 @@
+package com.swp391.OnlineEnglishLearningSystem.service;
+
+public interface RoleService {
+}

--- a/src/main/java/com/swp391/OnlineEnglishLearningSystem/service/UserService.java
+++ b/src/main/java/com/swp391/OnlineEnglishLearningSystem/service/UserService.java
@@ -3,7 +3,10 @@ package com.swp391.OnlineEnglishLearningSystem.service;
 import com.swp391.OnlineEnglishLearningSystem.model.User;
 import com.swp391.OnlineEnglishLearningSystem.model.dto.UserDTO;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 //
 public interface UserService {
@@ -20,4 +23,14 @@ public interface UserService {
     boolean isOldPasswordCorrect(User currentUser, String oldPassword);
 
     User getById(Long userId);
+
+    List<User> getAllUsers();
+
+    User getUserById(Long id);
+
+    void deleteById(Long id);
+
+    Page<User> findPaginated(Pageable pageable);
+
+    Page<User> getUsersWithSpecs(Pageable pageale, String gender, String role, Boolean enabled, String search);
 }

--- a/src/main/java/com/swp391/OnlineEnglishLearningSystem/service/impl/RoleServiceImpl.java
+++ b/src/main/java/com/swp391/OnlineEnglishLearningSystem/service/impl/RoleServiceImpl.java
@@ -1,4 +1,20 @@
 package com.swp391.OnlineEnglishLearningSystem.service.impl;
 
-public class RoleServiceImpl {
+import com.swp391.OnlineEnglishLearningSystem.model.UserRole;
+import com.swp391.OnlineEnglishLearningSystem.repository.RoleRepository;
+import com.swp391.OnlineEnglishLearningSystem.service.RoleService;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class RoleServiceImpl implements RoleService {
+    private final RoleRepository roleRepository;
+    public RoleServiceImpl(RoleRepository roleRepository) {
+        this.roleRepository = roleRepository;
+    }
+    @Override
+    public List<UserRole> findAll() {
+        return this.roleRepository.findAll();
+    }
 }

--- a/src/main/java/com/swp391/OnlineEnglishLearningSystem/service/impl/RoleServiceImpl.java
+++ b/src/main/java/com/swp391/OnlineEnglishLearningSystem/service/impl/RoleServiceImpl.java
@@ -1,0 +1,4 @@
+package com.swp391.OnlineEnglishLearningSystem.service.impl;
+
+public class RoleServiceImpl {
+}

--- a/src/main/java/com/swp391/OnlineEnglishLearningSystem/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/swp391/OnlineEnglishLearningSystem/service/impl/UserServiceImpl.java
@@ -6,9 +6,16 @@ import com.swp391.OnlineEnglishLearningSystem.model.dto.UserDTO;
 import com.swp391.OnlineEnglishLearningSystem.repository.RoleRepository;
 import com.swp391.OnlineEnglishLearningSystem.repository.UserRepository;
 import com.swp391.OnlineEnglishLearningSystem.service.UserService;
+import com.swp391.OnlineEnglishLearningSystem.service.specification.UserSpecs;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -67,4 +74,42 @@ public class UserServiceImpl implements UserService {
     public User getById(Long userId) {
         return this.userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("User not found"));
     }
+
+    @Override
+    public List<User> getAllUsers() {
+        return this.userRepository.findAll();
+    }
+
+    @Override
+    public User getUserById(Long id) {
+        return userRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("User not found"));
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        userRepository.deleteById(id);
+    }
+
+    @Override
+    public Page<User> findPaginated(Pageable pageable) {
+        List<User> users = userRepository.findAll();
+        int pageSize = pageable.getPageSize();
+        int currentPage = pageable.getPageNumber();
+        int startItem = currentPage * pageSize;
+        List<User> list;
+        if (users.size() < startItem) {
+            list = Collections.emptyList();
+        }else{
+            int toIndex = Math.min(startItem + pageSize, users.size());
+            list = users.subList(startItem, toIndex);
+        }
+        return new PageImpl<>(list, pageable, users.size());
+    }
+
+    public Page<User> getUsersWithSpecs(Pageable pageable, String gender, String role, Boolean enabled, String search) {
+        Specification<User> spec = UserSpecs.withFilters(search, gender, role, enabled);
+        return userRepository.findAll(spec, pageable);
+    }
+
+
 }

--- a/src/main/java/com/swp391/OnlineEnglishLearningSystem/service/specification/UserSpecs.java
+++ b/src/main/java/com/swp391/OnlineEnglishLearningSystem/service/specification/UserSpecs.java
@@ -1,0 +1,4 @@
+package com.swp391.OnlineEnglishLearningSystem.service.specification;
+
+public class UserSpecs {
+}

--- a/src/main/java/com/swp391/OnlineEnglishLearningSystem/service/specification/UserSpecs.java
+++ b/src/main/java/com/swp391/OnlineEnglishLearningSystem/service/specification/UserSpecs.java
@@ -1,4 +1,111 @@
 package com.swp391.OnlineEnglishLearningSystem.service.specification;
 
+import org.springframework.data.jpa.domain.Specification;
+import com.swp391.OnlineEnglishLearningSystem.model.User;
+import com.swp391.OnlineEnglishLearningSystem.model.User.Gender;
+
 public class UserSpecs {
+
+    public static Specification<User> searchByGender(String gender) {
+        return (root, query, cb) -> {
+            if (gender == null || gender.equals("ALL")) {
+                return cb.conjunction();
+            }
+            try {
+                Gender genderEnum = Gender.valueOf(gender);
+                return cb.equal(root.get("gender"), genderEnum);
+            } catch (IllegalArgumentException e) {
+                return cb.conjunction();
+            }
+        };
+    }
+
+    public static Specification<User> searchByRole(String roleName) {
+        return (root, query, cb) -> {
+            if ((roleName == null) || roleName.equals("ALL") || roleName.isEmpty()) {
+                return cb.conjunction();
+            }
+            return cb.equal(root.get("role").get("name"), roleName);
+        };
+    }
+
+    public static Specification<User> searchByEnabled(Boolean enabled) {
+        return (root, query, cb) -> {
+            if (enabled == null) {
+                return cb.conjunction();
+            }
+            return cb.equal(root.get("enabled"), enabled);
+        };
+    }
+
+    public static Specification<User> searchByEnabled(String enabled) {
+        return (root, query, cb) -> {
+            if (enabled == null || enabled.equals("ALL")) {
+                return cb.conjunction();
+            }
+            Boolean enabledBool = Boolean.valueOf(enabled);
+            return cb.equal(root.get("enabled"), enabledBool);
+        };
+    }
+
+    public static Specification<User> searchByEmail(String email) {
+        return (root, query, cb) -> {
+            if (email == null || email.trim().isEmpty()) {
+                return cb.conjunction();
+            }
+            String likePattern = "%" + email.toLowerCase() + "%";
+            return cb.like(cb.lower(root.get("email")), likePattern);
+        };
+    }
+
+    public static Specification<User> searchByFullName(String fullName) {
+        return (root, query, cb) -> {
+            if (fullName == null || fullName.trim().isEmpty()) {
+                return cb.conjunction();
+            }
+            String likePattern = "%" + fullName.toLowerCase() + "%";
+            return cb.like(cb.lower(root.get("fullName")), likePattern);
+        };
+    }
+
+    public static Specification<User> searchByMobile(String mobile) {
+        return (root, query, cb) -> {
+            if (mobile == null || mobile.trim().isEmpty()) {
+                return cb.conjunction();
+            }
+            String likePattern = "%" + mobile + "%";
+            return cb.like(root.get("mobile"), likePattern);
+        };
+    }
+
+    public static Specification<User> searchByContainingEmailOrFullNameOrMobileKeyword(String keyword) {
+        return (root, query, cb) -> {
+            if (keyword == null || keyword.trim().isEmpty()) {
+                return cb.conjunction();
+            }
+
+            String likePattern = "%" + keyword.toLowerCase() + "%";
+            return cb.or(
+                    cb.like(cb.lower(root.get("email")), likePattern),
+                    cb.like(cb.lower(root.get("fullName")), likePattern),
+                    cb.like(root.get("mobile"), "%" + keyword + "%")
+            );
+        };
+    }
+
+    // Method để kết hợp tất cả các specifications
+    public static Specification<User> withFilters(String keyword, String gender, String role, Boolean enabled) {
+        return Specification.allOf(searchByContainingEmailOrFullNameOrMobileKeyword(keyword))
+                .and(searchByGender(gender))
+                .and(searchByRole(role))
+                .and(searchByEnabled(enabled));
+    }
+
+    public static Specification<User> withFilters(String keyword, String gender, String role, String enabled) {
+        Boolean enabledBool = null;
+        if (enabled != null && !enabled.equals("ALL")) {
+            enabledBool = Boolean.valueOf(enabled);
+        }
+        return withFilters(keyword, gender, role, enabledBool);
+    }
 }

--- a/src/main/resources/templates/admin/createUser.html
+++ b/src/main/resources/templates/admin/createUser.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>$Title$</title>
+</head>
+<body>
+$END$
+</body>
+</html>

--- a/src/main/resources/templates/admin/createUser.html
+++ b/src/main/resources/templates/admin/createUser.html
@@ -1,10 +1,244 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="vi" xmlns:th="http://www.thymeleaf.org">
 <head>
-  <meta charset="UTF-8">
-  <title>$Title$</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Tạo người dùng mới</title>
+    <style>
+        :root {
+            --primary-color: #6c63ff;
+            --primary-hover: #5a54d6;
+            --secondary-color: #4ecdc4;
+            --text-color: #333;
+            --text-light: #666;
+            --bg-color: #fff;
+            --bg-light: #f8f9fa;
+            --border-color: #e9ecef;
+            --shadow: 0 4px 20px rgba(0,0,0,0.08);
+            --radius: 12px;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 20px;
+        }
+
+        .form-container {
+            background: var(--bg-color);
+            border-radius: var(--radius);
+            box-shadow: var(--shadow);
+            padding: 40px;
+            width: 100%;
+            max-width: 600px;
+        }
+
+        .form-header {
+            text-align: center;
+            margin-bottom: 30px;
+        }
+
+        .form-header h1 {
+            color: var(--primary-color);
+            font-size: 28px;
+            font-weight: 600;
+            margin-bottom: 8px;
+        }
+
+        .form-header p {
+            color: var(--text-light);
+            font-size: 16px;
+        }
+
+        .form-group {
+            margin-bottom: 20px;
+        }
+
+        label {
+            display: block;
+            margin-bottom: 8px;
+            font-weight: 500;
+            color: var(--text-color);
+        }
+
+        .required::after {
+            content: " *";
+            color: #dc3545;
+        }
+
+        input, select {
+            width: 100%;
+            padding: 14px 16px;
+            border: 2px solid var(--border-color);
+            border-radius: var(--radius);
+            font-size: 16px;
+            transition: all 0.3s ease;
+            background: var(--bg-color);
+        }
+
+        input:focus, select:focus {
+            outline: none;
+            border-color: var(--primary-color);
+            box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.1);
+        }
+
+        .error {
+            color: #dc3545;
+            font-size: 14px;
+            margin-top: 5px;
+            display: block;
+        }
+
+        .form-actions {
+            display: flex;
+            gap: 15px;
+            margin-top: 30px;
+        }
+
+        .btn {
+            padding: 14px 28px;
+            border: none;
+            border-radius: var(--radius);
+            cursor: pointer;
+            font-size: 16px;
+            font-weight: 500;
+            text-decoration: none;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 8px;
+            transition: all 0.3s ease;
+            flex: 1;
+        }
+
+        .btn-primary {
+            background: var(--primary-color);
+            color: white;
+        }
+
+        .btn-primary:hover {
+            background: var(--primary-hover);
+            transform: translateY(-2px);
+        }
+
+        .btn-outline {
+            background: transparent;
+            color: var(--primary-color);
+            border: 2px solid var(--primary-color);
+        }
+
+        .btn-outline:hover {
+            background: var(--primary-color);
+            color: white;
+        }
+
+        .file-input {
+            padding: 12px;
+            border: 2px dashed var(--border-color);
+            border-radius: var(--radius);
+            text-align: center;
+            cursor: pointer;
+            transition: all 0.3s ease;
+        }
+
+        .file-input:hover {
+            border-color: var(--primary-color);
+            background: var(--bg-light);
+        }
+
+        @media (max-width: 768px) {
+            .form-container {
+                padding: 30px 20px;
+            }
+
+            .form-actions {
+                flex-direction: column;
+            }
+        }
+    </style>
 </head>
 <body>
-$END$
+<div class="form-container">
+    <div class="form-header">
+        <h1>👤 Tạo người dùng mới</h1>
+        <p>Thêm thông tin người dùng vào hệ thống</p>
+    </div>
+
+    <form th:action="@{/admin/users/create}" th:object="${user}" method="post" enctype="multipart/form-data">
+        <div class="form-group">
+            <label for="email" class="required">Email</label>
+            <input type="email" id="email" th:field="*{email}" placeholder="Nhập địa chỉ email">
+            <span th:if="${#fields.hasErrors('email')}" th:errors="*{email}" class="error"></span>
+        </div>
+
+        <div class="form-group">
+            <label for="password" class="required">Mật khẩu</label>
+            <input type="password" th:field="*{password}" id="password" placeholder="Nhập mật khẩu">
+            <span th:if="${#fields.hasErrors('password')}" th:errors="*{password}" class="error"></span>
+        </div>
+
+        <div class="form-group">
+            <label for="fullName" class="required">Họ và tên</label>
+            <input type="text" id="fullName" th:field="*{fullName}" placeholder="Nhập họ và tên đầy đủ">
+            <span th:if="${#fields.hasErrors('fullName')}" th:errors="*{fullName}" class="error"></span>
+        </div>
+
+        <div class="form-group">
+            <label for="gender" class="required">Giới tính</label>
+            <select th:field="*{gender}" id="gender">
+                <option th:each="gender : ${genders}"
+                        th:value="${gender}"
+                        th:text="${gender.displayName}"></option>
+            </select>
+        </div>
+
+        <div class="form-group">
+            <label for="role" class="required">Vai trò</label>
+            <select th:field="*{role}" id="role">
+                <option th:each="role : ${roles}"
+                        th:value="${role.id}"
+                        th:text="${role.name}"></option>
+            </select>
+        </div>
+
+        <div class="form-group">
+            <label for="mobile">Số điện thoại</label>
+            <input type="text" th:field="*{mobile}" id="mobile" placeholder="Nhập số điện thoại">
+            <span th:if="${#fields.hasErrors('mobile')}" th:errors="*{mobile}" class="error"></span>
+        </div>
+
+        <div class="form-group">
+            <label for="address">Địa chỉ</label>
+            <input type="text" th:field="*{address}" id="address" placeholder="Nhập địa chỉ">
+            <span th:if="${#fields.hasErrors('address')}" th:errors="*{address}" class="error"></span>
+        </div>
+
+        <div class="form-group">
+            <label for="avatar">Ảnh đại diện</label>
+            <input type="file" name="avatarFile" accept="image/*" id="avatar" class="file-input">
+        </div>
+
+        <input type="checkbox" th:field="*{enabled}" th:value="true" hidden>
+
+        <div class="form-actions">
+            <button type="submit" class="btn btn-primary">
+                <span>✓</span> Tạo người dùng
+            </button>
+            <a href="/admin/users" class="btn btn-outline">
+                <span>←</span> Quay lại
+            </a>
+        </div>
+    </form>
+</div>
 </body>
 </html>

--- a/src/main/resources/templates/admin/updateUser.html
+++ b/src/main/resources/templates/admin/updateUser.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>$Title$</title>
+</head>
+<body>
+$END$
+</body>
+</html>

--- a/src/main/resources/templates/admin/updateUser.html
+++ b/src/main/resources/templates/admin/updateUser.html
@@ -1,10 +1,266 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="vi" xmlns:th="http://www.thymeleaf.org">
 <head>
-  <meta charset="UTF-8">
-  <title>$Title$</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Cập nhật người dùng</title>
+    <style>
+        :root {
+            --primary-color: #6c63ff;
+            --primary-hover: #5a54d6;
+            --secondary-color: #4ecdc4;
+            --text-color: #333;
+            --text-light: #666;
+            --bg-color: #fff;
+            --bg-light: #f8f9fa;
+            --border-color: #e9ecef;
+            --shadow: 0 4px 20px rgba(0,0,0,0.08);
+            --radius: 12px;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 20px;
+        }
+
+        .form-container {
+            background: var(--bg-color);
+            border-radius: var(--radius);
+            box-shadow: var(--shadow);
+            padding: 40px;
+            width: 100%;
+            max-width: 600px;
+        }
+
+        .form-header {
+            text-align: center;
+            margin-bottom: 30px;
+        }
+
+        .form-header h1 {
+            color: var(--primary-color);
+            font-size: 28px;
+            font-weight: 600;
+            margin-bottom: 8px;
+        }
+
+        .form-header p {
+            color: var(--text-light);
+            font-size: 16px;
+        }
+
+        .user-info {
+            background: var(--bg-light);
+            padding: 20px;
+            border-radius: var(--radius);
+            margin-bottom: 25px;
+        }
+
+        .info-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 15px;
+        }
+
+        .info-item {
+            display: flex;
+            flex-direction: column;
+            gap: 5px;
+        }
+
+        .info-label {
+            font-size: 12px;
+            color: var(--text-light);
+            font-weight: 500;
+        }
+
+        .info-value {
+            font-size: 14px;
+            color: var(--text-color);
+            font-weight: 500;
+        }
+
+        .form-group {
+            margin-bottom: 20px;
+        }
+
+        label {
+            display: block;
+            margin-bottom: 8px;
+            font-weight: 500;
+            color: var(--text-color);
+        }
+
+        input, select {
+            width: 100%;
+            padding: 14px 16px;
+            border: 2px solid var(--border-color);
+            border-radius: var(--radius);
+            font-size: 16px;
+            transition: all 0.3s ease;
+            background: var(--bg-color);
+        }
+
+        input:focus, select:focus {
+            outline: none;
+            border-color: var(--primary-color);
+            box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.1);
+        }
+
+        input[readonly] {
+            background: var(--bg-light);
+            color: var(--text-light);
+            cursor: not-allowed;
+        }
+
+        .error {
+            color: #dc3545;
+            font-size: 14px;
+            margin-top: 5px;
+            display: block;
+        }
+
+        .form-actions {
+            display: flex;
+            gap: 15px;
+            margin-top: 30px;
+        }
+
+        .btn {
+            padding: 14px 28px;
+            border: none;
+            border-radius: var(--radius);
+            cursor: pointer;
+            font-size: 16px;
+            font-weight: 500;
+            text-decoration: none;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 8px;
+            transition: all 0.3s ease;
+            flex: 1;
+        }
+
+        .btn-primary {
+            background: var(--primary-color);
+            color: white;
+        }
+
+        .btn-primary:hover {
+            background: var(--primary-hover);
+            transform: translateY(-2px);
+        }
+
+        .btn-outline {
+            background: transparent;
+            color: var(--primary-color);
+            border: 2px solid var(--primary-color);
+        }
+
+        .btn-outline:hover {
+            background: var(--primary-color);
+            color: white;
+        }
+
+        @media (max-width: 768px) {
+            .form-container {
+                padding: 30px 20px;
+            }
+
+            .form-actions {
+                flex-direction: column;
+            }
+
+            .info-grid {
+                grid-template-columns: 1fr;
+            }
+        }
+    </style>
 </head>
 <body>
-$END$
+<div class="form-container">
+    <div class="form-header">
+        <h1>✏️ Cập nhật người dùng</h1>
+        <p>Chỉnh sửa thông tin vai trò và trạng thái người dùng</p>
+    </div>
+
+    <div class="user-info">
+        <div class="info-grid">
+            <div class="info-item">
+                <span class="info-label">ID</span>
+                <span class="info-value" th:text="${user.id}"></span>
+            </div>
+            <div class="info-item">
+                <span class="info-label">Email</span>
+                <span class="info-value" th:text="${user.email}"></span>
+            </div>
+            <div class="info-item">
+                <span class="info-label">Họ tên</span>
+                <span class="info-value" th:text="${user.fullName}"></span>
+            </div>
+            <div class="info-item">
+                <span class="info-label">Giới tính</span>
+                <span class="info-value" th:text="${user.gender.displayName}"></span>
+            </div>
+            <div class="info-item">
+                <span class="info-label">Số điện thoại</span>
+                <span class="info-value" th:text="${user.mobile ?: 'N/A'}"></span>
+            </div>
+            <div class="info-item">
+                <span class="info-label">Địa chỉ</span>
+                <span class="info-value" th:text="${user.address ?: 'N/A'}"></span>
+            </div>
+        </div>
+    </div>
+
+    <form th:action="@{/admin/users/update}" th:object="${user}" method="post">
+        <input type="hidden" th:field="*{id}">
+        <input type="hidden" th:field="*{email}">
+        <input type="hidden" th:field="*{password}">
+        <input type="hidden" th:field="*{fullName}">
+        <input type="hidden" th:field="*{gender}">
+        <input type="hidden" th:field="*{mobile}">
+        <input type="hidden" th:field="*{address}">
+
+        <div class="form-group">
+            <label for="role">Vai trò</label>
+            <select th:field="*{role}" id="role">
+                <option th:each="role : ${roles}"
+                        th:value="${role.id}"
+                        th:text="${role.name}"
+                        th:selected="${user.role.id == role.id}"></option>
+            </select>
+        </div>
+
+        <div class="form-group">
+            <label for="enabled">Trạng thái</label>
+            <select th:field="*{enabled}" id="enabled">
+                <option th:value="true" th:selected="${user.enabled}">Đang hoạt động</option>
+                <option th:value="false" th:selected="${!user.enabled}">Không hoạt động</option>
+            </select>
+        </div>
+
+        <div class="form-actions">
+            <button type="submit" class="btn btn-primary">
+                <span>✓</span> Cập nhật
+            </button>
+            <a href="/admin/users" class="btn btn-outline">
+                <span>←</span> Quay lại
+            </a>
+        </div>
+    </form>
+</div>
 </body>
 </html>

--- a/src/main/resources/templates/admin/userList.html
+++ b/src/main/resources/templates/admin/userList.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>$Title$</title>
+</head>
+<body>
+$END$
+</body>
+</html>

--- a/src/main/resources/templates/admin/userList.html
+++ b/src/main/resources/templates/admin/userList.html
@@ -1,10 +1,534 @@
 <!DOCTYPE html>
-<html lang="en">
+<html xmlns:th="http://www.thymeleaf.org" lang="vi">
 <head>
-  <meta charset="UTF-8">
-  <title>$Title$</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Quản lý Người dùng</title>
+    <style>
+        :root {
+            --primary-color: #6c63ff;
+            --primary-hover: #5a54d6;
+            --secondary-color: #4ecdc4;
+            --text-color: #333;
+            --text-light: #666;
+            --bg-color: #fff;
+            --bg-light: #f8f9fa;
+            --border-color: #e9ecef;
+            --shadow: 0 4px 20px rgba(0,0,0,0.08);
+            --radius: 12px;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background-color: var(--bg-light);
+            color: var(--text-color);
+            line-height: 1.6;
+            padding: 20px;
+        }
+
+        .container {
+            max-width: 1400px;
+            margin: 0 auto;
+            background: var(--bg-color);
+            border-radius: var(--radius);
+            box-shadow: var(--shadow);
+            padding: 30px;
+        }
+
+        .header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 30px;
+            padding-bottom: 20px;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .header h1 {
+            color: var(--primary-color);
+            font-size: 28px;
+            font-weight: 600;
+        }
+
+        .btn {
+            padding: 12px 24px;
+            border: none;
+            border-radius: var(--radius);
+            cursor: pointer;
+            font-size: 14px;
+            font-weight: 500;
+            text-decoration: none;
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            transition: all 0.3s ease;
+        }
+
+        .btn-primary {
+            background: var(--primary-color);
+            color: white;
+        }
+
+        .btn-primary:hover {
+            background: var(--primary-hover);
+            transform: translateY(-2px);
+        }
+
+        .btn-outline {
+            background: transparent;
+            color: var(--primary-color);
+            border: 2px solid var(--primary-color);
+        }
+
+        .btn-outline:hover {
+            background: var(--primary-color);
+            color: white;
+        }
+
+        .btn-danger {
+            background: #dc3545;
+            color: white;
+        }
+
+        .btn-danger:hover {
+            background: #c82333;
+        }
+
+        .btn-sm {
+            padding: 8px 16px;
+            font-size: 12px;
+        }
+
+        .filters {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 20px;
+            margin-bottom: 30px;
+            padding: 25px;
+            background: var(--bg-light);
+            border-radius: var(--radius);
+            border: 1px solid var(--border-color);
+        }
+
+        .filter-group {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+
+        .filter-group label {
+            font-size: 14px;
+            font-weight: 500;
+            color: var(--text-light);
+        }
+
+        .search-box {
+            grid-column: 1 / -1;
+        }
+
+        select, input {
+            padding: 12px 16px;
+            border: 2px solid var(--border-color);
+            border-radius: var(--radius);
+            font-size: 14px;
+            transition: all 0.3s ease;
+            background: var(--bg-color);
+        }
+
+        select:focus, input:focus {
+            outline: none;
+            border-color: var(--primary-color);
+            box-shadow: 0 0 0 3px rgba(108, 99, 255, 0.1);
+        }
+
+        .table-container {
+            overflow-x: auto;
+            border-radius: var(--radius);
+            border: 1px solid var(--border-color);
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            background: var(--bg-color);
+        }
+
+        th {
+            background: var(--bg-light);
+            padding: 16px 12px;
+            text-align: left;
+            font-weight: 600;
+            color: var(--text-color);
+            border-bottom: 2px solid var(--border-color);
+            cursor: pointer;
+            transition: background-color 0.3s ease;
+            position: relative;
+        }
+
+        th:hover {
+            background: #e9ecef;
+        }
+
+        th a {
+            color: inherit;
+            text-decoration: none;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .sort-icon {
+            color: var(--primary-color);
+            font-weight: bold;
+        }
+
+        td {
+            padding: 16px 12px;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        tr:hover {
+            background: var(--bg-light);
+        }
+
+        .status-active {
+            color: #28a745;
+            font-weight: 600;
+            padding: 6px 12px;
+            background: #d4edda;
+            border-radius: 20px;
+            font-size: 12px;
+        }
+
+        .status-inactive {
+            color: #dc3545;
+            font-weight: 600;
+            padding: 6px 12px;
+            background: #f8d7da;
+            border-radius: 20px;
+            font-size: 12px;
+        }
+
+        .actions {
+            display: flex;
+            gap: 8px;
+        }
+
+        .pagination {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            gap: 8px;
+            margin-top: 30px;
+            flex-wrap: wrap;
+        }
+
+        .pagination a {
+            padding: 10px 16px;
+            border: 2px solid var(--border-color);
+            border-radius: var(--radius);
+            text-decoration: none;
+            color: var(--text-color);
+            transition: all 0.3s ease;
+            font-weight: 500;
+        }
+
+        .pagination a:hover {
+            border-color: var(--primary-color);
+            color: var(--primary-color);
+        }
+
+        .pagination a.active {
+            background: var(--primary-color);
+            color: white;
+            border-color: var(--primary-color);
+        }
+
+        .no-data {
+            text-align: center;
+            padding: 40px;
+            color: var(--text-light);
+        }
+
+        @media (max-width: 768px) {
+            .filters {
+                grid-template-columns: 1fr;
+            }
+
+            .header {
+                flex-direction: column;
+                gap: 20px;
+                align-items: flex-start;
+            }
+
+            .actions {
+                flex-direction: column;
+            }
+        }
+    </style>
 </head>
 <body>
-$END$
+<div class="container">
+    <div class="header">
+        <h1>📊 Quản lý Người dùng</h1>
+        <a href="/admin/users/create" class="btn btn-primary">
+            <span>+</span> Thêm người dùng mới
+        </a>
+    </div>
+
+    <div class="filters">
+        <div class="filter-group">
+            <label>Giới tính</label>
+            <select id="genderFilter" onchange="applyFilters()">
+                <option value="ALL">Tất cả giới tính</option>
+                <option th:each="gender : ${genders}"
+                        th:value="${gender}"
+                        th:text="${gender.displayName}"
+                        th:selected="${param.gender == gender}"></option>
+            </select>
+        </div>
+
+        <div class="filter-group">
+            <label>Vai trò</label>
+            <select id="roleFilter" onchange="applyFilters()">
+                <option value="ALL">Tất cả vai trò</option>
+                <option th:each="role : ${roles}"
+                        th:value="${role.name}"
+                        th:text="${role.name}"
+                        th:selected="${param.role == role.name}"></option>
+            </select>
+        </div>
+
+        <div class="filter-group">
+            <label>Trạng thái</label>
+            <select id="enabledFilter" onchange="applyFilters()">
+                <option value="ALL">Tất cả trạng thái</option>
+                <option value="true" th:selected="${param.enabled == 'true'}">Đang hoạt động</option>
+                <option value="false" th:selected="${param.enabled == 'false'}">Không hoạt động</option>
+            </select>
+        </div>
+
+        <div class="filter-group">
+            <label>Tìm kiếm</label>
+            <div style="display: flex; gap: 10px;">
+                <input type="text"
+                       id="searchInput"
+                       placeholder="Tìm theo tên, email hoặc số điện thoại..."
+                       th:value="${param.search}">
+            </div>
+        </div>
+    </div>
+
+    <div class="table-container">
+        <table id="usersTable">
+            <thead>
+            <tr>
+                <th>
+                    <a th:href="@{/admin/users(
+                            page=0,
+                            size=${userPage.size},
+                            sort='id',
+                            direction=${(currentSort == 'id' and currentDirection == 'asc') ? 'desc' : 'asc'},
+                            search=${param.search},
+                            gender=${param.gender},
+                            role=${param.role},
+                            enabled=${param.enabled}
+                        )}">
+                        ID
+                        <span th:if="${currentSort == 'id'}" class="sort-icon">
+                                <span th:text="${currentDirection == 'asc'} ? '↑' : '↓'"></span>
+                            </span>
+                    </a>
+                </th>
+                <th>
+                    <a th:href="@{/admin/users(
+                            page=0,
+                            size=${userPage.size},
+                            sort='fullName',
+                            direction=${(currentSort == 'fullName' and currentDirection == 'asc') ? 'desc' : 'asc'},
+                            search=${param.search},
+                            gender=${param.gender},
+                            role=${param.role},
+                            enabled=${param.enabled}
+                        )}">
+                        Họ tên
+                        <span th:if="${currentSort == 'fullName'}" class="sort-icon">
+                                <span th:text="${currentDirection == 'asc'} ? '↑' : '↓'"></span>
+                            </span>
+                    </a>
+                </th>
+                <th>
+                    <a th:href="@{/admin/users(
+                            page=0,
+                            size=${userPage.size},
+                            sort='gender',
+                            direction=${(currentSort == 'gender' and currentDirection == 'asc') ? 'desc' : 'asc'},
+                            search=${param.search},
+                            gender=${param.gender},
+                            role=${param.role},
+                            enabled=${param.enabled}
+                        )}">
+                        Giới tính
+                        <span th:if="${currentSort == 'gender'}" class="sort-icon">
+                                <span th:text="${currentDirection == 'asc'} ? '↑' : '↓'"></span>
+                            </span>
+                    </a>
+                </th>
+                <th>
+                    <a th:href="@{/admin/users(
+                            page=0,
+                            size=${userPage.size},
+                            sort='email',
+                            direction=${(currentSort == 'email' and currentDirection == 'asc') ? 'desc' : 'asc'},
+                            search=${param.search},
+                            gender=${param.gender},
+                            role=${param.role},
+                            enabled=${param.enabled}
+                        )}">
+                        Email
+                        <span th:if="${currentSort == 'email'}" class="sort-icon">
+                                <span th:text="${currentDirection == 'asc'} ? '↑' : '↓'"></span>
+                            </span>
+                    </a>
+                </th>
+                <th>
+                    <a th:href="@{/admin/users(
+                            page=0,
+                            size=${userPage.size},
+                            sort='mobile',
+                            direction=${(currentSort == 'mobile' and currentDirection == 'asc') ? 'desc' : 'asc'},
+                            search=${param.search},
+                            gender=${param.gender},
+                            role=${param.role},
+                            enabled=${param.enabled}
+                        )}">
+                        Số điện thoại
+                        <span th:if="${currentSort == 'mobile'}" class="sort-icon">
+                                <span th:text="${currentDirection == 'asc'} ? '↑' : '↓'"></span>
+                            </span>
+                    </a>
+                </th>
+                <th>
+                    <a th:href="@{/admin/users(
+                            page=0,
+                            size=${userPage.size},
+                            sort='role',
+                            direction=${(currentSort == 'role' and currentDirection == 'asc') ? 'desc' : 'asc'},
+                            search=${param.search},
+                            gender=${param.gender},
+                            role=${param.role},
+                            enabled=${param.enabled}
+                        )}">
+                        Vai trò
+                        <span th:if="${currentSort == 'role'}" class="sort-icon">
+                                <span th:text="${currentDirection == 'asc'} ? '↑' : '↓'"></span>
+                            </span>
+                    </a>
+                </th>
+                <th>Trạng thái</th>
+                <th>Hành động</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="user : ${userPage.content}" th:unless="${userPage.content.empty}">
+                <td th:text="${user.id}"></td>
+                <td th:text="${user.fullName}"></td>
+                <td th:text="${user.gender.displayName}"></td>
+                <td th:text="${user.email}"></td>
+                <td th:text="${user.mobile ?: 'N/A'}"></td>
+                <td th:text="${user.role.name}"></td>
+                <td>
+                    <span th:if="${user.enabled}" class="status-active">Đang hoạt động</span>
+                    <span th:unless="${user.enabled}" class="status-inactive">Không hoạt động</span>
+                </td>
+                <td>
+                    <div class="actions">
+                        <a th:href="@{/admin/users/update/{id}(id=${user.id})}"
+                           class="btn btn-outline btn-sm">✏️ Sửa</a>
+                        <a th:href="@{/admin/users/delete/{id}(id=${user.id})}"
+                           class="btn btn-danger btn-sm"
+                           onclick="return confirm('Bạn có chắc chắn muốn xóa người dùng này?')">🗑️ Xóa</a>
+                    </div>
+                </td>
+            </tr>
+            <tr th:if="${userPage.content.empty}">
+                <td colspan="8" class="no-data">
+                    📝 Không tìm thấy người dùng nào
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <div th:if="${userPage.totalPages > 0}" class="pagination">
+        <a th:each="pageNumber : ${pageNumbers}"
+           th:href="@{/admin/users(
+                   size=${userPage.size},
+                   page=${pageNumber - 1},
+                   sort=${currentSort},
+                   direction=${currentDirection},
+                   search=${param.search},
+                   gender=${param.gender},
+                   role=${param.role},
+                   enabled=${param.enabled}
+               )}"
+           th:text="${pageNumber}"
+           th:class="${pageNumber == userPage.number + 1} ? 'active' : ''"></a>
+    </div>
+</div>
+
+<script>
+    function applyFilters() {
+        const gender = document.getElementById('genderFilter').value;
+        const role = document.getElementById('roleFilter').value;
+        const enabled = document.getElementById('enabledFilter').value;
+        const search = document.getElementById('searchInput').value;
+
+        const urlParams = new URLSearchParams();
+
+        if (gender !== 'ALL') urlParams.set('gender', gender);
+        if (role !== 'ALL') urlParams.set('role', role);
+        if (enabled !== 'ALL') urlParams.set('enabled', enabled);
+        if (search) urlParams.set('search', search);
+
+        // Giữ lại sort parameters nếu có
+        const currentUrl = new URL(window.location.href);
+        const currentSort = currentUrl.searchParams.get('sort');
+        const currentDirection = currentUrl.searchParams.get('direction');
+
+        if (currentSort) urlParams.set('sort', currentSort);
+        if (currentDirection) urlParams.set('direction', currentDirection);
+
+        window.location.href = '/admin/users?' + urlParams.toString();
+    }
+
+    document.getElementById('searchInput').addEventListener('keypress', function(e) {
+        if (e.key === 'Enter') {
+            applyFilters();
+        }
+    });
+
+    // Auto-select current filter values from URL
+    document.addEventListener('DOMContentLoaded', function() {
+        const urlParams = new URLSearchParams(window.location.search);
+
+        // Set values from URL parameters
+        const gender = urlParams.get('gender');
+        const role = urlParams.get('role');
+        const enabled = urlParams.get('enabled');
+        const search = urlParams.get('search');
+
+        if (gender) document.getElementById('genderFilter').value = gender;
+        if (role) document.getElementById('roleFilter').value = role;
+        if (enabled) document.getElementById('enabledFilter').value = enabled;
+        if (search) document.getElementById('searchInput').value = search;
+    });
+</script>
 </body>
 </html>


### PR DESCRIPTION
Show the paginated list of registered users (include users' id, full name, gender, email, mobile, role, status):
- The admin can filter the users by gender, role, status
- Allow the admin to seach users by full name, email, mobile
- The list is sortable by id, fullname, gender, email, mobile, role, status
- From each user, the admin can choose to view or edit it
- The page also have the button/link that allows the admin to add new user
Show detailed user information (avatar, full name, gender, email, mobile, role, address, status), from that allow the user to add new, view or edit user information
- After adding, new generated login password would be email to the new user
- The admin can only edit/update the role and status of the user